### PR TITLE
Jade change repository

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "component/domify": "*",
     "visionmedia/debug": "*",
-    "jadejs/jade": "1.11.0",
+    "pugjs/jade": "1.11.0",
     "cristiandouce/query": "*"
   },
   "development": {


### PR DESCRIPTION
Jade moves from https://github.com/jadejs/jade to https://github.com/pugjs/jade