### PR TITLE
Remove Video Tutorials link

### DIFF
--- a/template.jade
+++ b/template.jade
@@ -53,9 +53,6 @@ nav.navbar.navbar-default(role='navigation')
               a(href="#{base_url}/resources") Resources
               
             li
-              a(href="#{base_url}/video-tutorials") Video Tutorials
-              
-            li
               a(href="#{base_url}/partners") Partners
 
             li


### PR DESCRIPTION
Video Tutorials page was removed in: https://github.com/auth0/auth0-website/pull/573