### PR TITLE
Adding Custom Auth Element

### DIFF
--- a/src/components/WebHeader/WebHeader.js
+++ b/src/components/WebHeader/WebHeader.js
@@ -38,8 +38,7 @@ class WebHeader extends Component {
     talkToSalesButtonLink: PropTypes.string,
     talkToSalesButtonOnClick: PropTypes.func,
     talkToSalesButtonText: PropTypes.string,
-    authElementEnable: PropTypes.bool,
-    authElement: PropTypes.node,
+    userProfile: PropTypes.node,
     breakpoint: PropTypes.number
   };
 
@@ -65,8 +64,7 @@ class WebHeader extends Component {
     talkToSalesButtonLink: '?contact=true',
     talkToSalesButtonOnClick: () => {},
     talkToSalesButtonText: 'Talk to Sales',
-    authElementEnable: false,
-    authElement: null,
+    userProfile: null,
     breakpoint: 992
   };
 
@@ -178,8 +176,7 @@ class WebHeader extends Component {
       loginButtonLink,
       loginButtonOnClick,
       loginButtonText,
-      authElementEnable,
-      authElement
+      userProfile
     } = this.props;
     const {
       navbarDropdownIsOpen,
@@ -295,7 +292,7 @@ class WebHeader extends Component {
                 >
                   {loginButtonEnable && loginButton}
                   {signupButtonEnable && signupButton}
-                  {authElementEnable && authElement}
+                  {userProfile}
                 </div>
               </div>
             </div>

--- a/src/components/WebHeader/WebHeader.js
+++ b/src/components/WebHeader/WebHeader.js
@@ -38,6 +38,8 @@ class WebHeader extends Component {
     talkToSalesButtonLink: PropTypes.string,
     talkToSalesButtonOnClick: PropTypes.func,
     talkToSalesButtonText: PropTypes.string,
+    authElementEnable: PropTypes.bool,
+    authElement: PropTypes.node,
     breakpoint: PropTypes.number
   };
 
@@ -63,6 +65,8 @@ class WebHeader extends Component {
     talkToSalesButtonLink: '?contact=true',
     talkToSalesButtonOnClick: () => {},
     talkToSalesButtonText: 'Talk to Sales',
+    authElementEnable: false,
+    authElement: null,
     breakpoint: 992
   };
 
@@ -173,7 +177,9 @@ class WebHeader extends Component {
       loginButtonEnable,
       loginButtonLink,
       loginButtonOnClick,
-      loginButtonText
+      loginButtonText,
+      authElementEnable,
+      authElement
     } = this.props;
     const {
       navbarDropdownIsOpen,
@@ -289,6 +295,7 @@ class WebHeader extends Component {
                 >
                   {loginButtonEnable && loginButton}
                   {signupButtonEnable && signupButton}
+                  {authElementEnable && authElement}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Currently the only option is to have a button or text, this adds the ability to add in your own node, which we will use in Docs to put the user dropdown in this area.

This is how it looks with my custom element:
![image](https://user-images.githubusercontent.com/1422227/32579952-f9400706-c497-11e7-9946-e3b2227d3d2d.png)
